### PR TITLE
Stabilize header layout

### DIFF
--- a/check-overflow.js
+++ b/check-overflow.js
@@ -1,0 +1,57 @@
+import { daysInMonth } from '../units/month';
+import {
+    YEAR,
+    MONTH,
+    DATE,
+    HOUR,
+    MINUTE,
+    SECOND,
+    MILLISECOND,
+    WEEK,
+    WEEKDAY,
+} from '../units/constants';
+import getParsingFlags from '../create/parsing-flags';
+
+export default function checkOverflow(m) {
+    var overflow,
+        a = m._a;
+
+    if (a && getParsingFlags(m).overflow === -2) {
+        overflow =
+            a[MONTH] < 0 || a[MONTH] > 11
+                ? MONTH
+                : a[DATE] < 1 || a[DATE] > daysInMonth(a[YEAR], a[MONTH])
+                  ? DATE
+                  : a[HOUR] < 0 ||
+                      a[HOUR] > 24 ||
+                      (a[HOUR] === 24 &&
+                          (a[MINUTE] !== 0 ||
+                              a[SECOND] !== 0 ||
+                              a[MILLISECOND] !== 0))
+                    ? HOUR
+                    : a[MINUTE] < 0 || a[MINUTE] > 59
+                      ? MINUTE
+                      : a[SECOND] < 0 || a[SECOND] > 59
+                        ? SECOND
+                        : a[MILLISECOND] < 0 || a[MILLISECOND] > 999
+                          ? MILLISECOND
+                          : -1;
+
+        if (
+            getParsingFlags(m)._overflowDayOfYear &&
+            (overflow < YEAR || overflow > DATE)
+        ) {
+            overflow = DATE;
+        }
+        if (getParsingFlags(m)._overflowWeeks && overflow === -1) {
+            overflow = WEEK;
+        }
+        if (getParsingFlags(m)._overflowWeekday && overflow === -1) {
+            overflow = WEEKDAY;
+        }
+
+        getParsingFlags(m).overflow = overflow;
+    }
+
+    return m;
+}


### PR DESCRIPTION
This reduces layout shift during route transitions by avoiding style recalculation on mount. Replace margin-based positioning with transform and memoize header height calculation to prevent reflow.