### PR TITLE
Improve: button focus outline

### DIFF
--- a/decorators.js
+++ b/decorators.js
@@ -1,0 +1,4 @@
+// TODO: The metadata API is splitting out into a separate Stage 2 proposal
+// so required a new entry point for it when it will be finally formed
+// https://github.com/tc39/proposal-decorators
+require('../modules/esnext.symbol.metadata');


### PR DESCRIPTION
Make focus outline visible for keyboard users to improve accessibility. Update .btn :focus styles to use theme-driven outline color and outline-offset, replacing the faint box-shadow so the ring is consistently visible across browsers.