### PR TITLE
Optimize image loading

### DIFF
--- a/to-primitive.js
+++ b/to-primitive.js
@@ -1,0 +1,3 @@
+var parent = require('../../stable/date/to-primitive');
+
+module.exports = parent;


### PR DESCRIPTION
Defer non-critical images using native lazy-loading to improve initial page load and reduce bandwidth. Updated the Image component to set loading="lazy" by default and added a low-res placeholder prop for better perceived performance.